### PR TITLE
Implement loader options with support for a specific twig path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ module.exports = {
 
 ```
 
+#### Options
+
+- `twigPath`: optional; an absolute path pointing to the `twig` module. 
+    This ensures that a same Twig instance is used for both project templates and package templates.
+    Defaults to `'twig'`.
+
+  Example: `path.resolve(process.cwd(), 'node_modules/twig')`
+
 ### With Express
 
 [example](examples/express), [typescript example](examples/typescript)

--- a/getOptions.js
+++ b/getOptions.js
@@ -1,0 +1,28 @@
+const getOptions = require('loader-utils').getOptions;
+const validateOptions = require('schema-utils');
+
+const schema = {
+  type: 'object',
+  properties: {
+    twigPath: {
+      type: 'string',
+    },
+  },
+  additionalProperties: false,
+};
+
+const defaultOptions = {
+  twigPath: 'twig',
+};
+
+module.exports = (loader) => {
+  const loaderOptions = getOptions(loader);
+
+  if (loaderOptions === null) {
+    return {};
+  }
+
+  validateOptions(schema, loaderOptions, 'twigjs-loader');
+
+  return Object.assign({}, defaultOptions, loaderOptions);
+};

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 const path = require('path');
 const Twig = require('twig');
 
+const getOptions = require('./getOptions');
+
 module.exports = twigLoader;
 module.exports.ExpressView = ExpressView;
 module.exports.default = module.exports;
@@ -10,6 +12,8 @@ module.exports.default = module.exports;
 Twig.cache(false);
 
 function twigLoader(source) {
+  const options = getOptions(this);
+
   const callback = this.async();
 
   const template = Twig.twig({
@@ -20,12 +24,12 @@ function twigLoader(source) {
     rethrow: true,
   });
 
-  compile(this, template)
+  compile(this, template, options.twigPath)
     .then(output => callback(null, output))
     .catch(err => callback(err));
 }
 
-async function compile(loaderApi, template) {
+async function compile(loaderApi, template, twigPath) {
   let dependencies = [];
   await each(template.tokens, processToken);
 
@@ -42,7 +46,7 @@ async function compile(loaderApi, template) {
 
   return `
     ${dependenciesString}
-    var twig = require("twig").twig;
+    var twig = require("${twigPath}").twig;
     var tpl = twig(${JSON.stringify(twigData)});
     module.exports = function(context) { return tpl.render(context); };
     module.exports.id = ${JSON.stringify(template.id)};

--- a/package.json
+++ b/package.json
@@ -45,5 +45,9 @@
     "express": "^4.16.3",
     "mocha": "*",
     "twig": "*"
+  },
+  "dependencies": {
+    "loader-utils": "^1.2.3",
+    "schema-utils": "^2.4.1"
   }
 }

--- a/spec/templates/embed-simple.twig
+++ b/spec/templates/embed-simple.twig
@@ -22,12 +22,14 @@ new header
 {% endembed %}
 
 {% embed "embed-base.twig" %}
+{% block header %}
 {% embed "embed-include.twig" %}
 {% block header %}
 Super cool new header
 {% endblock %}
 {% endembed %}
-{% block footer%}
+{% endblock %}
+{% block footer %}
 Cool footer
 {% endblock %}
 {% endembed %}


### PR DESCRIPTION
During development we encountered a `TwigError` stating that a particular template could not be found. The template that triggered the error was using a macro from another npm package and after some debugging it turned out that this setup was the root cause of the error. The output of the loader uses a generic `var twig = require("twig").twig;` and that causes webpack to use a different instance of Twig for templates of the project and templates from other npm packages. 

This pull request adds the ability to use a `twigPath` option in the webpack loader configuration to ensure that the same Twig instance is used for all templates that are being loaded.

Example:
```
{
  test: /\.twig$/,
  loader: 'twigjs-loader',
  options: {
    twigPath: path.resolve(process.cwd(), 'node_modules/twig'),
  },
}
```

While working on this pull request I noticed that the tests were broken and it turned out that this was caused by a change in the twig.js package: https://github.com/twigjs/twig.js/pull/537. I applied the changes mentioned in the pull request to the affected template and that fixed the tests.