### PR TITLE
Added apply and setcapture token type

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,9 @@ async function compile(loaderApi, template) {
       case 'Twig.logic.type.else':
       case 'Twig.logic.type.for':
       case 'Twig.logic.type.spaceless':
-      case 'Twig.logic.type.macro': {
+      case 'Twig.logic.type.macro':
+      case 'Twig.logic.type.apply':
+      case 'Twig.logic.type.setcapture': {
         await each(token.token.output, processToken);
         break;
       }


### PR DESCRIPTION
Dependencies (`includes` in my case) did not get resolved when they have been wrapped in...

1.) ... a combination of the apply tag with the spaceless filter.
```twig
{% apply spaceless %}
    <div>
        {% include '@atoms/path/file.twig' %}
    </div>
{% endapply %}
```

2.) ... the set tag is used to capture chunks of text.
```twig
{% set someVariable %}
    <div>
        {% include '@atoms/path/file.twig' %}
    </div>
{% endset %}
```