### PR TITLE
Deterministic dependencies order

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ async function compile(loaderApi, template) {
   };
 
   const dependenciesString = unique(dependencies)
+    .sort()
     .map(d => `require(${JSON.stringify(d)});`)
     .join('\n');
 


### PR DESCRIPTION
#### Background
When running Webpack in production mode a `contenthash` is generated. This is based on the entire compiled content of the file. About 15% of the time the contenthash would be different while the codebase hasn't changed. After a long debugging session I managed to find that one of our TwigJS template had two `include` calls which resulted in two dependencies. The order of the dependencies somehow got flipped in some cases. This can cause major havoc when dealing with multiple servers.

Snippet from the generated files:
```
// 85% of the time
module.exports.id="some_template.html.twig",module.exports.default=module.exports},35160:function(module,__unused_webpack_exports,__webpack_require__){  
__webpack_require__(40057),__webpack_require__(74374)

// 15% of the time
module.exports.id="some_template.html.twig",module.exports.default=module.exports},35160:function(module,__unused_webpack_exports,__webpack_require__){  
__webpack_require__(74374),__webpack_require__(40057)
```
_Edit: Added blank line for clarity._

#### Proposed solution
By adding `.sort()` to the dependencies I've managed to always get the same content.

For testing purposes I also tried `.sort().reverse()` and I indeed got the "wrong" order consistently.


I hope this helps. Any feedback is appreciated.